### PR TITLE
Use associated constants for simple constants like these.

### DIFF
--- a/src/bls12_381/fq.rs
+++ b/src/bls12_381/fq.rs
@@ -459,21 +459,15 @@ impl PrimeField for Fq {
         MODULUS
     }
 
-    fn num_bits() -> u32 {
-        MODULUS_BITS
-    }
+    const NUM_BITS: u32 = MODULUS_BITS;
 
-    fn capacity() -> u32 {
-        Self::num_bits() - 1
-    }
+    const CAPACITY: u32 = Self::NUM_BITS - 1;
 
     fn multiplicative_generator() -> Self {
         Fq(GENERATOR)
     }
 
-    fn s() -> u32 {
-        S
-    }
+    const S: u32 = S;
 
     fn root_of_unity() -> Self {
         Fq(ROOT_OF_UNITY)
@@ -1500,20 +1494,20 @@ fn test_fq_display() {
 
 #[test]
 fn test_fq_num_bits() {
-	assert_eq!(Fq::num_bits(), 381);
-	assert_eq!(Fq::capacity(), 380);
+	assert_eq!(Fq::NUM_BITS, 381);
+	assert_eq!(Fq::CAPACITY, 380);
 }
 
 #[test]
 fn test_fq_root_of_unity() {
-    assert_eq!(Fq::s(), 1);
+    assert_eq!(Fq::S, 1);
     assert_eq!(Fq::multiplicative_generator(), Fq::from_repr(FqRepr::from(2)).unwrap());
     assert_eq!(
         Fq::multiplicative_generator().pow([0xdcff7fffffffd555, 0xf55ffff58a9ffff, 0xb39869507b587b12, 0xb23ba5c279c2895f, 0x258dd3db21a5d66b, 0xd0088f51cbff34d]),
         Fq::root_of_unity()
     );
     assert_eq!(
-        Fq::root_of_unity().pow([1 << Fq::s()]),
+        Fq::root_of_unity().pow([1 << Fq::S]),
         Fq::one()
     );
     assert!(Fq::multiplicative_generator().sqrt().is_none());

--- a/src/bls12_381/fr.rs
+++ b/src/bls12_381/fr.rs
@@ -280,21 +280,15 @@ impl PrimeField for Fr {
         MODULUS
     }
 
-    fn num_bits() -> u32 {
-        MODULUS_BITS
-    }
+    const NUM_BITS: u32 = MODULUS_BITS;
 
-    fn capacity() -> u32 {
-        Self::num_bits() - 1
-    }
+    const CAPACITY: u32 = Self::NUM_BITS - 1;
 
     fn multiplicative_generator() -> Self {
         Fr(GENERATOR)
     }
 
-    fn s() -> u32 {
-        S
-    }
+    const S: u32 = S;
 
     fn root_of_unity() -> Self {
         Fr(ROOT_OF_UNITY)
@@ -1216,20 +1210,20 @@ fn test_fr_display() {
 
 #[test]
 fn test_fr_num_bits() {
-    assert_eq!(Fr::num_bits(), 255);
-    assert_eq!(Fr::capacity(), 254);
+    assert_eq!(Fr::NUM_BITS, 255);
+    assert_eq!(Fr::CAPACITY, 254);
 }
 
 #[test]
 fn test_fr_root_of_unity() {
-    assert_eq!(Fr::s(), 32);
+    assert_eq!(Fr::S, 32);
     assert_eq!(Fr::multiplicative_generator(), Fr::from_repr(FrRepr::from(7)).unwrap());
     assert_eq!(
         Fr::multiplicative_generator().pow([0xfffe5bfeffffffff, 0x9a1d80553bda402, 0x299d7d483339d808, 0x73eda753]),
         Fr::root_of_unity()
     );
     assert_eq!(
-        Fr::root_of_unity().pow([1 << Fr::s()]),
+        Fr::root_of_unity().pow([1 << Fr::S]),
         Fr::one()
     );
     assert!(Fr::multiplicative_generator().sqrt().is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,20 +540,18 @@ pub trait PrimeField: Field
     /// Returns the field characteristic; the modulus.
     fn char() -> Self::Repr;
 
-    /// Returns how many bits are needed to represent an element of this
-    /// field.
-    fn num_bits() -> u32;
+    /// How many bits are needed to represent an element of this field.
+    const NUM_BITS: u32;
 
-    /// Returns how many bits of information can be reliably stored in the
-    /// field element.
-    fn capacity() -> u32;
+    /// How many bits of information can be reliably stored in the field element.
+    const CAPACITY: u32;
 
     /// Returns the multiplicative generator of `char()` - 1 order. This element
     /// must also be quadratic nonresidue.
     fn multiplicative_generator() -> Self;
 
-    /// Returns s such that 2^s * t = `char()` - 1 with t odd.
-    fn s() -> u32;
+    /// 2^s * t = `char()` - 1 with t odd.
+    const S: u32;
 
     /// Returns the 2^s root of unity computed by exponentiating the `multiplicative_generator()`
     /// by t.


### PR DESCRIPTION
Closes #39.