### PR TITLE
Derive `Clone` for G1/G2 encodings.

### DIFF
--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -591,14 +591,8 @@ pub mod g1 {
 
     curve_impl!("G1", G1, G1Affine, G1Prepared, Fq, Fr, G1Uncompressed, G1Compressed, G2Affine);
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct G1Uncompressed([u8; 96]);
-
-    impl Clone for G1Uncompressed {
-        fn clone(&self) -> G1Uncompressed {
-            G1Uncompressed(self.0)
-        }
-    }
 
     impl AsRef<[u8]> for G1Uncompressed {
         fn as_ref(&self) -> &[u8] {
@@ -699,14 +693,8 @@ pub mod g1 {
         }
     }
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct G1Compressed([u8; 48]);
-
-    impl Clone for G1Compressed {
-        fn clone(&self) -> G1Compressed {
-            G1Compressed(self.0)
-        }
-    }
 
     impl AsRef<[u8]> for G1Compressed {
         fn as_ref(&self) -> &[u8] {
@@ -1100,14 +1088,8 @@ pub mod g2 {
 
     curve_impl!("G2", G2, G2Affine, G2Prepared, Fq2, Fr, G2Uncompressed, G2Compressed, G1Affine);
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct G2Uncompressed([u8; 192]);
-
-    impl Clone for G2Uncompressed {
-        fn clone(&self) -> G2Uncompressed {
-            G2Uncompressed(self.0)
-        }
-    }
 
     impl AsRef<[u8]> for G2Uncompressed {
         fn as_ref(&self) -> &[u8] {
@@ -1220,14 +1202,8 @@ pub mod g2 {
         }
     }
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct G2Compressed([u8; 96]);
-
-    impl Clone for G2Compressed {
-        fn clone(&self) -> G2Compressed {
-            G2Compressed(self.0)
-        }
-    }
 
     impl AsRef<[u8]> for G2Compressed {
         fn as_ref(&self) -> &[u8] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 #![cfg_attr(feature = "clippy", allow(too_many_arguments))]
 #![cfg_attr(feature = "clippy", allow(unreadable_literal))]
 #![cfg_attr(feature = "clippy", allow(new_without_default_derive))]
-#![cfg_attr(feature = "clippy", allow(expl_impl_clone_on_copy))] // TODO
 
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
AFAIK this will finally work on stable when the next version of Rust is released.

Closes #55 