### PR TITLE
Enforce that Fr of Engine is the scalar for curve points

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub trait CurveProjective: PartialEq +
                            rand::Rand +
                            'static
 {
-    type Engine: Engine;
+    type Engine: Engine<Fr=Self::Scalar>;
     type Scalar: PrimeField;
     type Base: SqrtField;
     type Affine: CurveAffine<Projective=Self, Scalar=Self::Scalar>;
@@ -166,7 +166,7 @@ pub trait CurveAffine: Copy +
                        Eq +
                        'static
 {
-    type Engine: Engine;
+    type Engine: Engine<Fr=Self::Scalar>;
     type Scalar: PrimeField;
     type Base: SqrtField;
     type Projective: CurveProjective<Affine=Self, Scalar=Self::Scalar>;


### PR DESCRIPTION
In bellman, I want to write:

```rust
pub struct Point<C: CurveProjective>(pub C);

impl<C: CurveProjective> Copy for Point<C> { }

impl<C: CurveProjective> Clone for Point<C> {
    fn clone(&self) -> Point<C> {
        *self
    }
}

impl<C: CurveProjective> Group<C::Engine> for Point<C> {
    fn group_zero() -> Self {
        Point(C::zero())
    }
    fn group_mul_assign(&mut self, by: &C::Scalar) {
        self.0.mul_assign(by.into_repr());
    }
    fn group_add_assign(&mut self, other: &Self) {
        self.0.add_assign(&other.0);
    }
    fn group_sub_assign(&mut self, other: &Self) {
        self.0.sub_assign(&other.0);
    }
}
```

However, this doesn't typecheck because the compiler cannot know that the `Engine`'s `Fr` type (as dictated by the `Group` trait) is the same as the `Scalar` type of the `CurveProjective` point. This can be solved with a where bound over the trait (for now), but it is generally a good idea for this to be constrained in `pairing`.