### PR TITLE
Release of 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pairing"
 
 # Remember to change version string in README.md.
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ebfull/pairing"
 [dependencies]
 rand = "0.3"
 byteorder = "1"
-clippy = { version = "0.0.165", optional = true }
+clippy = { version = "0.0.174", optional = true }
 
 [features]
 unstable-features = []


### PR DESCRIPTION
This release features the following changes:

* The `byteorder` version is now set to `1` as conventional.
* The `CurveAffine`/`CurveProjective` traits now enforce that the scalar field of the `Engine` is the same scalar field for the curves.
* `Engine` is now `'static` and `Clone` to avoid problems with lifetime quirks and auto-derives.
* The scalar field of `Engine` is now guaranteed to be `SqrtField` which helps downstream abstractions.

In this PR I will be updating the `clippy` version and fixing any linting problems that show up. The builder should be using the newest nightly/stable versions of Rust also.