### PR TITLE
Rust 1.19 compatibility

### DIFF
--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -629,8 +629,14 @@ pub mod g1 {
 
     curve_impl!("G1", G1, G1Affine, G1Prepared, Fq, Fr, G1Uncompressed, G1Compressed, G2Affine);
 
-    #[derive(Copy, Clone)]
+    #[derive(Copy)]
     pub struct G1Uncompressed([u8; 96]);
+
+    impl Clone for G1Uncompressed {
+        fn clone(&self) -> G1Uncompressed {
+            G1Uncompressed(self.0)
+        }
+    }
 
     impl AsRef<[u8]> for G1Uncompressed {
         fn as_ref(&self) -> &[u8] {
@@ -731,8 +737,14 @@ pub mod g1 {
         }
     }
 
-    #[derive(Copy, Clone)]
+    #[derive(Copy)]
     pub struct G1Compressed([u8; 48]);
+
+    impl Clone for G1Compressed {
+        fn clone(&self) -> G1Compressed {
+            G1Compressed(self.0)
+        }
+    }
 
     impl AsRef<[u8]> for G1Compressed {
         fn as_ref(&self) -> &[u8] {
@@ -1091,8 +1103,14 @@ pub mod g2 {
 
     curve_impl!("G2", G2, G2Affine, G2Prepared, Fq2, Fr, G2Uncompressed, G2Compressed, G1Affine);
 
-    #[derive(Copy, Clone)]
+    #[derive(Copy)]
     pub struct G2Uncompressed([u8; 192]);
+
+    impl Clone for G2Uncompressed {
+        fn clone(&self) -> G2Uncompressed {
+            G2Uncompressed(self.0)
+        }
+    }
 
     impl AsRef<[u8]> for G2Uncompressed {
         fn as_ref(&self) -> &[u8] {
@@ -1205,8 +1223,14 @@ pub mod g2 {
         }
     }
 
-    #[derive(Copy, Clone)]
+    #[derive(Copy)]
     pub struct G2Compressed([u8; 96]);
+
+    impl Clone for G2Compressed {
+        fn clone(&self) -> G2Compressed {
+            G2Compressed(self.0)
+        }
+    }
 
     impl AsRef<[u8]> for G2Compressed {
         fn as_ref(&self) -> &[u8] {

--- a/src/bls12_381/fq.rs
+++ b/src/bls12_381/fq.rs
@@ -432,6 +432,10 @@ impl From<Fq> for FqRepr {
     }
 }
 
+const Fq_NUM_BITS: u32 = MODULUS_BITS;
+const Fq_CAPACITY: u32 = Fq_NUM_BITS - 1;
+const Fq_S: u32 = S;
+
 impl PrimeField for Fq {
     type Repr = FqRepr;
 
@@ -459,15 +463,9 @@ impl PrimeField for Fq {
         MODULUS
     }
 
-    const NUM_BITS: u32 = MODULUS_BITS;
-
-    const CAPACITY: u32 = Self::NUM_BITS - 1;
-
     fn multiplicative_generator() -> Self {
         Fq(GENERATOR)
     }
-
-    const S: u32 = S;
 
     fn root_of_unity() -> Self {
         Fq(ROOT_OF_UNITY)
@@ -1494,8 +1492,8 @@ fn test_fq_display() {
 
 #[test]
 fn test_fq_num_bits() {
-	assert_eq!(Fq::NUM_BITS, 381);
-	assert_eq!(Fq::CAPACITY, 380);
+	assert_eq!(Fq_NUM_BITS, 381);
+	assert_eq!(Fq_CAPACITY, 380);
 }
 
 #[test]

--- a/src/bls12_381/fr.rs
+++ b/src/bls12_381/fr.rs
@@ -254,6 +254,10 @@ impl From<Fr> for FrRepr {
     }
 }
 
+const Fr_NUM_BITS: u32 = MODULUS_BITS;
+const Fr_CAPACITY: u32 = Fr_NUM_BITS - 1;
+const Fr_S: u32 = S;
+
 impl PrimeField for Fr {
     type Repr = FrRepr;
 
@@ -280,15 +284,9 @@ impl PrimeField for Fr {
         MODULUS
     }
 
-    const NUM_BITS: u32 = MODULUS_BITS;
-
-    const CAPACITY: u32 = Self::NUM_BITS - 1;
-
     fn multiplicative_generator() -> Self {
         Fr(GENERATOR)
     }
-
-    const S: u32 = S;
 
     fn root_of_unity() -> Self {
         Fr(ROOT_OF_UNITY)
@@ -1210,8 +1208,8 @@ fn test_fr_display() {
 
 #[test]
 fn test_fr_num_bits() {
-    assert_eq!(Fr::NUM_BITS, 255);
-    assert_eq!(Fr::CAPACITY, 254);
+    assert_eq!(Fr_NUM_BITS, 255);
+    assert_eq!(Fr_CAPACITY, 254);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(feature = "clippy", allow(too_many_arguments))]
 #![cfg_attr(feature = "clippy", allow(unreadable_literal))]
 #![cfg_attr(feature = "clippy", allow(new_without_default_derive))]
+#![cfg_attr(feature = "clippy", allow(expl_impl_clone_on_copy))] // TODO
 
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,18 +540,20 @@ pub trait PrimeField: Field
     /// Returns the field characteristic; the modulus.
     fn char() -> Self::Repr;
 
+    // These constants have been commented out for Rust 1.19 compatibility
+
     /// How many bits are needed to represent an element of this field.
-    const NUM_BITS: u32;
+    // const NUM_BITS: u32;
 
     /// How many bits of information can be reliably stored in the field element.
-    const CAPACITY: u32;
+    // const CAPACITY: u32;
+
+    /// 2^s * t = `char()` - 1 with t odd.
+    // const S: u32;
 
     /// Returns the multiplicative generator of `char()` - 1 order. This element
     /// must also be quadratic nonresidue.
     fn multiplicative_generator() -> Self;
-
-    /// 2^s * t = `char()` - 1 with t odd.
-    const S: u32;
 
     /// Returns the 2^s root of unity computed by exponentiating the `multiplicative_generator()`
     /// by t.


### PR DESCRIPTION
This rolls back the use of a couple of post 1.19 features, so that we can use the `rustc-1.19.0` built via `mrustc` to build `powersoftau`.