### PR TITLE
Release of pairing 0.14.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pairing"
 
 # Remember to change version string in README.md.
-version = "0.13.2"
+version = "0.14.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you're using a supported platform and the nightly Rust compiler, you can enab
 
 ```toml
 [dependencies.pairing]
-version = "0.13"
+version = "0.14"
 features = ["u128-support"]
 ```
 


### PR DESCRIPTION
This release makes some changes in response to an audit of this library, as well as some obversations about the API that I made. Some names were changed (`divn` -> `shr`, `muln` -> `shl`) and `add_nocarry`/`sub_noborrow` no longer return anything (as their names would suggest.) Some potentially misleading comments are fixed as well.

The release also applies `rustfmt` and new lints from `clippy` to the codebase, enforced by the CI on a more recent version of the Nightly compiler.

Thanks go to @jasondavies for his contributions to this release.