### PR TITLE
Remove feature(i128_type)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ebfull/pairing"
 [dependencies]
 rand = "0.4"
 byteorder = "1"
-clippy = { version = "0.0.186", optional = true }
+clippy = { version = "0.0.190", optional = true }
 
 [features]
 unstable-features = ["expose-arith"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pairing"
 
 # Remember to change version string in README.md.
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/src/bls12_381/fq.rs
+++ b/src/bls12_381/fq.rs
@@ -2135,15 +2135,14 @@ fn test_fq_repr_sub_noborrow() {
         0x7c0577a26f59d5,
     ]));
     assert!(
-        t
-            == FqRepr([
-                0x40a12b8967c54bae,
-                0xdeae37a0837d0d7b,
-                0xe592c487bae374e,
-                0xaf26bbc934462a61,
-                0x32d6cc6e2b7a4a03,
-                0xcdaf23e091c0313
-            ])
+        t == FqRepr([
+            0x40a12b8967c54bae,
+            0xdeae37a0837d0d7b,
+            0xe592c487bae374e,
+            0xaf26bbc934462a61,
+            0x32d6cc6e2b7a4a03,
+            0xcdaf23e091c0313
+        ])
     );
 
     for _ in 0..1000 {
@@ -2223,15 +2222,14 @@ fn test_fq_repr_add_nocarry() {
         0x7c0577a26f59d5,
     ]));
     assert!(
-        t
-            == FqRepr([
-                0xcfae1db798be8c04,
-                0x999906db15a10d5a,
-                0x270fa8d9defc6f79,
-                0x83abb199c240f7b6,
-                0x27469abae93e1ff6,
-                0xdd2fd2d4dfab6be
-            ])
+        t == FqRepr([
+            0xcfae1db798be8c04,
+            0x999906db15a10d5a,
+            0x270fa8d9defc6f79,
+            0x83abb199c240f7b6,
+            0x27469abae93e1ff6,
+            0xdd2fd2d4dfab6be
+        ])
     );
 
     // Test for the associativity of addition.
@@ -2575,15 +2573,14 @@ fn test_fq_mul_assign() {
         0x1162b680fb8e9566,
     ])));
     assert!(
-        tmp
-            == Fq(FqRepr([
-                0x9dc4000001ebfe14,
-                0x2850078997b00193,
-                0xa8197f1abb4d7bf,
-                0xc0309573f4bfe871,
-                0xf48d0923ffaf7620,
-                0x11d4b58c7a926e66
-            ]))
+        tmp == Fq(FqRepr([
+            0x9dc4000001ebfe14,
+            0x2850078997b00193,
+            0xa8197f1abb4d7bf,
+            0xc0309573f4bfe871,
+            0xf48d0923ffaf7620,
+            0x11d4b58c7a926e66
+        ]))
     );
 
     let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);

--- a/src/bls12_381/fr.rs
+++ b/src/bls12_381/fr.rs
@@ -849,13 +849,12 @@ fn test_fr_repr_sub_noborrow() {
         0x298a30c744b31acf,
     ]));
     assert!(
-        t
-            == FrRepr([
-                0xb813415048991c1f,
-                0x10ad07ae88725d92,
-                0x5a7b851271759961,
-                0x36850eedd30c39c5
-            ])
+        t == FrRepr([
+            0xb813415048991c1f,
+            0x10ad07ae88725d92,
+            0x5a7b851271759961,
+            0x36850eedd30c39c5
+        ])
     );
 
     for _ in 0..1000 {
@@ -1252,13 +1251,12 @@ fn test_fr_mul_assign() {
         0x5ae3f03b561a841d,
     ])));
     assert!(
-        tmp
-            == Fr(FrRepr([
-                0x23717213ce710f71,
-                0xdbee1fe53a16e1af,
-                0xf565d3e1c2a48000,
-                0x4426507ee75df9d7
-            ]))
+        tmp == Fr(FrRepr([
+            0x23717213ce710f71,
+            0xdbee1fe53a16e1af,
+            0xf565d3e1c2a48000,
+            0x4426507ee75df9d7
+        ]))
     );
 
     let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);

--- a/src/bls12_381/mod.rs
+++ b/src/bls12_381/mod.rs
@@ -350,7 +350,7 @@ impl G2Prepared {
         coeffs.push(doubling_step(&mut r));
 
         G2Prepared {
-            coeffs: coeffs,
+            coeffs,
             infinity: false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-// If the "u128-support" feature is enabled, this library can use
-// more efficient arithmetic. Only available in the nightly compiler.
-#![cfg_attr(feature = "u128-support", feature(i128_type))]
 // `clippy` is a code linting tool for improving code quality by catching
 // common mistakes or strange code patterns. If the `clippy` feature is
 // provided, it is enabled and all compiler warnings are prohibited.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,42 +36,42 @@ pub trait Engine: Sized + 'static + Clone {
 
     /// The projective representation of an element in G1.
     type G1: CurveProjective<
-        Engine = Self,
-        Base = Self::Fq,
-        Scalar = Self::Fr,
-        Affine = Self::G1Affine,
-    >
+            Engine = Self,
+            Base = Self::Fq,
+            Scalar = Self::Fr,
+            Affine = Self::G1Affine,
+        >
         + From<Self::G1Affine>;
 
     /// The affine representation of an element in G1.
     type G1Affine: CurveAffine<
-        Engine = Self,
-        Base = Self::Fq,
-        Scalar = Self::Fr,
-        Projective = Self::G1,
-        Pair = Self::G2Affine,
-        PairingResult = Self::Fqk,
-    >
+            Engine = Self,
+            Base = Self::Fq,
+            Scalar = Self::Fr,
+            Projective = Self::G1,
+            Pair = Self::G2Affine,
+            PairingResult = Self::Fqk,
+        >
         + From<Self::G1>;
 
     /// The projective representation of an element in G2.
     type G2: CurveProjective<
-        Engine = Self,
-        Base = Self::Fqe,
-        Scalar = Self::Fr,
-        Affine = Self::G2Affine,
-    >
+            Engine = Self,
+            Base = Self::Fqe,
+            Scalar = Self::Fr,
+            Affine = Self::G2Affine,
+        >
         + From<Self::G2Affine>;
 
     /// The affine representation of an element in G2.
     type G2Affine: CurveAffine<
-        Engine = Self,
-        Base = Self::Fqe,
-        Scalar = Self::Fr,
-        Projective = Self::G2,
-        Pair = Self::G1Affine,
-        PairingResult = Self::Fqk,
-    >
+            Engine = Self,
+            Base = Self::Fqe,
+            Scalar = Self::Fr,
+            Projective = Self::G2,
+            Pair = Self::G1Affine,
+            PairingResult = Self::Fqk,
+        >
         + From<Self::G2>;
 
     /// The base field that hosts G1.
@@ -110,8 +110,8 @@ pub trait Engine: Sized + 'static + Clone {
 
 /// Projective representation of an elliptic curve point guaranteed to be
 /// in the correct prime order subgroup.
-pub trait CurveProjective
-    : PartialEq
+pub trait CurveProjective:
+    PartialEq
     + Eq
     + Sized
     + Copy
@@ -121,7 +121,8 @@ pub trait CurveProjective
     + fmt::Debug
     + fmt::Display
     + rand::Rand
-    + 'static {
+    + 'static
+{
     type Engine: Engine<Fr = Self::Scalar>;
     type Scalar: PrimeField + SqrtField;
     type Base: SqrtField;
@@ -180,9 +181,9 @@ pub trait CurveProjective
 
 /// Affine representation of an elliptic curve point guaranteed to be
 /// in the correct prime order subgroup.
-pub trait CurveAffine
-    : Copy + Clone + Sized + Send + Sync + fmt::Debug + fmt::Display + PartialEq + Eq + 'static
-    {
+pub trait CurveAffine:
+    Copy + Clone + Sized + Send + Sync + fmt::Debug + fmt::Display + PartialEq + Eq + 'static
+{
     type Engine: Engine<Fr = Self::Scalar>;
     type Scalar: PrimeField + SqrtField;
     type Base: SqrtField;
@@ -232,8 +233,9 @@ pub trait CurveAffine
 }
 
 /// An encoded elliptic curve point, which should essentially wrap a `[u8; N]`.
-pub trait EncodedPoint
-    : Sized + Send + Sync + AsRef<[u8]> + AsMut<[u8]> + Clone + Copy + 'static {
+pub trait EncodedPoint:
+    Sized + Send + Sync + AsRef<[u8]> + AsMut<[u8]> + Clone + Copy + 'static
+{
     type Affine: CurveAffine;
 
     /// Creates an empty representation.
@@ -261,9 +263,9 @@ pub trait EncodedPoint
 }
 
 /// This trait represents an element of a field.
-pub trait Field
-    : Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + rand::Rand
-    {
+pub trait Field:
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + rand::Rand
+{
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self;
 
@@ -334,8 +336,8 @@ pub trait SqrtField: Field {
 /// This trait represents a wrapper around a biginteger which can encode any element of a particular
 /// prime field. It is a smart wrapper around a sequence of `u64` limbs, least-significant digit
 /// first.
-pub trait PrimeFieldRepr
-    : Sized
+pub trait PrimeFieldRepr:
+    Sized
     + Copy
     + Clone
     + Eq
@@ -349,7 +351,8 @@ pub trait PrimeFieldRepr
     + rand::Rand
     + AsRef<[u64]>
     + AsMut<[u64]>
-    + From<u64> {
+    + From<u64>
+{
     /// Subtract another represetation from this one.
     fn sub_noborrow(&mut self, other: &Self);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,7 @@ impl<E: AsRef<[u64]>> BitIterator<E> {
     pub fn new(t: E) -> Self {
         let n = t.as_ref().len() * 64;
 
-        BitIterator { t: t, n: n }
+        BitIterator { t, n }
     }
 }
 

--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -102,7 +102,7 @@ impl<G: CurveProjective> Wnaf<(), Vec<G>, Vec<i64>> {
         Wnaf {
             base: &self.base[..],
             scalar: &mut self.scalar,
-            window_size: window_size,
+            window_size,
         }
     }
 
@@ -123,7 +123,7 @@ impl<G: CurveProjective> Wnaf<(), Vec<G>, Vec<i64>> {
         Wnaf {
             base: &mut self.base,
             scalar: &self.scalar[..],
-            window_size: window_size,
+            window_size,
         }
     }
 }


### PR DESCRIPTION
The `i128_type` feature was recently stabilized in Rust, so this is unnecessary now for nightly users. In fact, in a few days there should be a new Rust beta (`1.26`) containing stable support for `i128_type`, meaning that (for Zcash) we can switch to the beta compiler for all future Rust development, and even switch to the stable compiler in six weeks when that's released.